### PR TITLE
[WIP]Koku object refactor

### DIFF
--- a/kokuqe/api.py
+++ b/kokuqe/api.py
@@ -123,7 +123,7 @@ class Client(object):
 
     def __init__(
             self, response_handler=None, url=None,
-            authenticate=True, server_username=None, server_password=None):
+            authenticate=True, username=None, password=None):
         """Initialize this object, collecting base URL from config file.
 
         If no response handler is specified, use the `code_handler` which will
@@ -147,8 +147,8 @@ class Client(object):
             response_handler - Customer handler wrapper for formatting response
             url - Url for the Koku server. Default is localhost (127.0.0.1)
             authenticate - If True, login to the server during initialization
-            server_username - Username used for server authentication
-            server_password - Password used for server authentication
+            username - Username used for server authentication
+            password - Password used for server authentication
         """
         # Stores the response of the last request made.
         self._last_response = None
@@ -183,24 +183,21 @@ class Client(object):
             self.response_handler = response_handler
 
         if authenticate:
-            self.login(username=server_username, password=server_password)
+            self.login(username=username, password=password)
 
-    def login(self, username=None, password=None):
+    def login(self, username, password):
         """Login to the server to receive an authorization token.
         
         Arguments:
             username - Username for initial server authentication
             password - Password for initial server authentication
         """
-        cfg = config.get_config().get('koku', {})
-        server_username = username or cfg.get('username', KOKU_DEFAULT_USER)
-        server_password = password or cfg.get('password', KOKU_DEFAULT_PASSWORD)
         login_request = self.request(
             'POST',
             urljoin(self.url, KOKU_TOKEN_PATH),
             json={
-                'username': server_username,
-                'password': server_password
+                'username': username,
+                'password': password
             }
         )
         self.token = login_request.json()['token']

--- a/kokuqe/koku_models.py
+++ b/kokuqe/koku_models.py
@@ -4,9 +4,11 @@
 from pprint import pformat
 from urllib.parse import urljoin
 
-from kokuqe import api
+from kokuqe import api, config
 from kokuqe.exceptions import KokuException
 from kokuqe.constants import (
+    KOKU_DEFAULT_USER,
+    KOKU_DEFAULT_PASSWORD,
     KOKU_CUSTOMER_PATH,
     KOKU_USER_PATH,
 )
@@ -23,7 +25,8 @@ class KokuObject(object):
     def __init__(
             self,
             client=None,
-            uuid=None):
+            uuid=None,
+            authenticate=False):
         """Provide shared methods for KOKU model objects.
 
         Arguments:
@@ -31,7 +34,7 @@ class KokuObject(object):
             uuid - Koku uuid for the Koku object
         """
         self.uuid = uuid
-        self.client = client if client else api.Client()
+        self.client = client if client else api.Client(authenticate=authenticate)
         self.endpoint = ''
 
     def fields(self):
@@ -85,7 +88,11 @@ class KokuObject(object):
         """Return true if both objects are not equal."""
         return not self == other
 
-    def create(self, **kwargs):
+    def get_current_user(self):
+        """Send GET request return the user assigned to the client authentication token"""
+        return self.client.get_user()
+
+    def _create(self, client=None, **kwargs):
         """Send POST request to the self.endpoint of this object.
 
         :param ``**kwargs``: Additional arguments accepted by Requests's
@@ -100,12 +107,14 @@ class KokuObject(object):
         :returns: requests.models.Response. The json of this response contains
             the data associated with this object's ``self.uuid``.
         """
-        response = self.client.post(self.endpoint, self.payload(), **kwargs)
+        client = client or self.client
+
+        response = client.post(self.endpoint, self.payload(), **kwargs)
         if response.status_code in range(200, 203):
             self.uuid = response.json().get('uuid')
         return response
 
-    def list(self, **kwargs):
+    def _list(self, client=None, **kwargs):
         """Send GET request to read all objects of this type.
 
         :param ``**kwargs``: Additional arguments accepted by Requests's
@@ -115,9 +124,11 @@ class KokuObject(object):
             contains a list of dictionaries with the data associated with each
             object of this type stored on the server.
         """
-        return self.client.get(self.endpoint, **kwargs)
+        client = client or self.client
 
-    def read(self, **kwargs):
+        return client.get(self.endpoint, **kwargs)
+
+    def _read(self, client=None, **kwargs):
         """Send GET request to the self.endpoint/{id} of this object.
 
         :param ``**kwargs``: Additional arguments accepted by Requests's
@@ -126,9 +137,10 @@ class KokuObject(object):
         :returns: requests.models.Response. The json of this response contains
             the data associated with this object's `self.uuid`.
         """
-        return self.client.get(self.path(), **kwargs)
+        client = client or self.client
+        return client.get(self.path(), **kwargs)
 
-    def update(self, **kwargs):
+    def _update(self, client=None, **kwargs):
         """Send PUT request to the self.endpoint/{id} of this object.
 
         :param ``**kwargs``: Additional arguments accepted by Requests's
@@ -141,9 +153,11 @@ class KokuObject(object):
         :returns: requests.models.Response. The json of this response contains
             the data associated with this object's `self.uuid`.
         """
-        return self.client.put(self.path(), self.update_payload(), **kwargs)
+        client = client or self.client
 
-    def delete(self, **kwargs):
+        return client.put(self.path(), self.update_payload(), **kwargs)
+
+    def _delete(self, client=None, **kwargs):
         """Send DELETE request to the self.endpoint/{id} of this object.
 
         :param ``**kwargs``: Additional arguments accepted by Requests's
@@ -152,7 +166,17 @@ class KokuObject(object):
         :returns: requests.models.Response. A successful delete has the return
             code `204`.
         """
-        return self.client.delete(self.path(), **kwargs)
+        client = client or self.client
+
+        return client.delete(self.path(), **kwargs)
+
+    #TODO: Refactor payload() & fields()
+    def load(self, payload):
+        """Populate the object data from the response of a GET request
+        Arguments:
+            payload - dictionary object from json response
+        """
+        raise NotImplementedError
 
     def reload(self):
         """Send a GET request based on the current uuid to reload the current member data"""
@@ -172,19 +196,112 @@ class KokuObject(object):
     def last_response(self):
         """Return the response of the most recent Koku rest api call
 
-        Returns ```kokuqe.api.Client.last_response```
+        Returns ``kokuqe.api.Client.last_response``
         """
         return self.client.last_response
 
 
-class KokuCustomer(KokuObject):
-    """A class to create a Koku customer"""
+class KokuServiceAdmin(KokuObject):
+    """Class to perform actions as the Koku Service Admin"""
 
-    def __init__(self, client=None, uuid=None, name=None, owner=None):
+    def __init__(self, client=None, username=None, password=None):
         """
         Arguments:
-            client - Existing `kokuqe.api.client` object to use for authentication.
-                This client authentication will determine what koku features client has access to
+            client - existing ``kokuqe.api.Client`` instance used to communicate with the Koku
+                server. client authenticaton credentials will be used even if username & password
+                are provided
+            username - username to use for authentication
+            password - password to use for authentication
+        """
+        cfg = config.get_config().get('koku', {})
+        self.username = username or cfg.get('username', KOKU_DEFAULT_USER)
+        self.password = password or cfg.get('password', KOKU_DEFAULT_PASSWORD)
+
+        self.client = client if client else api.Client(
+            username=self.username, password=self.password)
+
+        self.uuid = None
+
+    def login(self):
+        """Login as the currently assigned service admin user"""
+        self.client.login(self.username, self.password)
+        return self.client.token is not None
+
+    def create_customer(self, name, owner):
+        """Create a Koku Customer object
+
+        Args:
+            name - Name of the customer
+            owner - Customer owner information
+                Dictionary Keys:
+                    username - Username for the owner
+                    email - Owner email address
+                    password - Owner user password
+
+        Returns: ``kokuqe.koku_models.KokuCustomer`` object
+        """
+        customer = KokuCustomer(name=name, owner=owner)
+        customer._create(self.client)
+        return customer
+
+    def read_customer(self, uuid):
+        """Get a Koku Customer object with assigned uuid
+
+        Args:
+            uuid - Koku uuid of the customer to retrieve
+
+        Returns: ``kokuqe.koku_models.KokuCustomer`` object
+        """
+        customer = KokuCustomer(uuid=uuid)
+        customer.load(customer._read(self.client).json())
+        return customer
+
+    def delete_customer(self, uuid):
+        """Delete a Koku Customer object with assigned uuid
+
+        Args:
+            uuid - Koku uuid of the customer to delete
+        """
+        customer = KokuCustomer(uuid=uuid)
+        customer._delete(self.client)
+
+    def list_customers(self):
+        """Retrieve the list of customers on the Koku Server
+
+        Returns: List of ``kokuqe.koku_models.KokuCustomer`` objects
+        """
+        customer_list = []
+        self.client.get(KOKU_CUSTOMER_PATH)
+        assert self.client.last_response, 'Unable to retrieve customer list in {}.list_customers()'.format(
+            self.__class__)
+
+        for customer_response in self.last_response.json()['results']:
+            cust = KokuCustomer()
+            cust.load(customer_response)
+            customer_list.append(cust)
+
+        return customer_list
+
+    def delete_provider(self, uuid):
+        """Delete the provider specified by uuid
+
+        Arguments:
+            uuid - Koku uuid of the provider to delete
+        """
+        #TODO: Verify that only service admin can delete the provider since user can add a provider
+        raise NotImplementedError
+
+
+class KokuCustomer(KokuObject):
+    """A class to manage a Koku customer and its users"""
+
+    def __init__(self, client=None, uuid=None, name=None, owner=None):
+        """Initialize this object with customer information.
+
+        Arguments:
+            client - If None, un-authenticated ``kokuqe.api.client`` will be created
+                else, Existing  object to use for authentication.
+                If provided, client authentication should match any supplied customer with name.
             uuid - UUID of an existing customer
             name - Name of the customer
             owner - Customer owner information
@@ -193,13 +310,90 @@ class KokuCustomer(KokuObject):
                     email - Owner email address
                     password - Owner user password
         """
-        super().__init__(client=client, uuid=uuid)
-        self.endpoint = KOKU_CUSTOMER_PATH
+        super().__init__(client=client, uuid=uuid, authenticate=False)
+        # If no client specified create ``api.Client`` with no authentication
+        self.client = client or api.Client(authenticate=False)
         self.name = name
         self.owner = owner
+        self.endpoint = KOKU_CUSTOMER_PATH
+
+    def login(self):
+        """Login as the customer owner
+        Authentication info is provided by the ``KokuCustomer.owner`` dictionary
+        """
+        self.client.login(self.owner['username'], self.owner['password'])
+        return self.client.token is not None
+
+    def load(self, payload):
+        """Populate the object data from the response of a GET request
+
+        Arguments:
+            payload - dictionary object from json response
+        """
+        self.uuid = payload['uuid']
+        self.name = payload['name']
+        self.owner = payload['owner']
+
+    def create_user(self, username, email, password=None):
+        """Create a Koku User object
+
+        Args:
+            uuid - UUID of an existing customer
+            username - Username for the user
+            email - User email address
+            password - User password
+
+        Returns: ``kokuqe.koku_models.KokuUser`` object
+        """
+        user = KokuUser(username=username, email=email, password=password)
+        user._create(self.client)
+        return user
+
+    def read_user(self, uuid):
+        """Get a Koku User object with assigned uuid
+
+        Args:
+            uuid - Koku uuid of the user to retrieve
+
+        Returns: ``kokuqe.koku_models.KokuUser`` object
+        """
+        user = KokuUser(uuid=uuid)
+        user.load(user._read(self.client).json())
+        return user
+
+
+    def delete_user(self, uuid):
+        """Delete a Koku User object with assigned uuid
+
+        Args:
+            uuid - Koku uuid of the user to delete
+        """
+        user = KokuUser(uuid=uuid)
+        user._delete(self.client)
+
+    #TODO: This should be in KokuObject since all authenticated 'users' can query
+    def list_users(self):
+        """Retrieve the list of users on the Koku Server
+
+        Returns: List of ``kokuqe.koku_models.KokuUser`` objects
+        """
+        user_list = []
+        self.client.get(KOKU_USER_PATH)
+
+        assert self.client.last_response, 'Unable to retrieve user list in {}.list_users()'.format(
+            self.__class__)
+
+        for user_response in self.last_response.json()['results']:
+            tmp_user = KokuUser()
+            tmp_user.load(user_response)
+            user_list.append(tmp_user)
+
+        return user_list
 
 
 class KokuUser(KokuObject):
+    """Manage a Koku User account"""
+
     def __init__(self, client=None, uuid=None, username=None, email=None, password=None):
         """
         Arguments:
@@ -211,10 +405,10 @@ class KokuUser(KokuObject):
             password - User password
         """
         super().__init__(client=client, uuid=uuid)
-        self.endpoint = KOKU_USER_PATH
         self.username = username
         self.email = email
         self.password = password
+        self.endpoint = KOKU_USER_PATH
 
     def __enter__(self):
         self._orig_token = self.client.token
@@ -224,9 +418,30 @@ class KokuUser(KokuObject):
         self.client.token = self._orig_token
         self._orig_token = None
 
-    def read_current_user(self):
-        """Send GET request return the user assigned to the client authentication token"""
-        return self.client.get_user()
+    def load(self, payload):
+        """Populate the object data from the response of a GET request
+
+        Arguments:
+            payload - dictionary object from json response
+        """
+        self.uuid = payload['uuid']
+        self.username = payload['username']
+        self.email = payload['email']
+        self.password = None
+
+    def login(self):
+        """Login as the currently assigned user"""
+        self.client.login(self.username, self.password)
+        return self.client.token is not None
+
+    def create_provider(self):
+        raise NotImplementedError
+
+    def read_provider(self):
+        raise NotImplementedError
+
+    def list_providers(self):
+        raise NotImplementedError
 
     def path_user_preference(self, pref_uuid=None):
         """Return the endpoint for a user preference
@@ -239,6 +454,7 @@ class KokuUser(KokuObject):
             '{}/'.format(pref_uuid) if pref_uuid else '')
         return pref_path
 
+    #TODO: Create a user preference subclass
     def create_preference(self, name, preference, description=None):
         """Send POST request to create a user preference
 

--- a/kokuqe/tests/api/conftest.py
+++ b/kokuqe/tests/api/conftest.py
@@ -3,16 +3,19 @@ import fauxfactory
 import pytest
 
 from kokuqe import config
-from kokuqe.koku_models import KokuCustomer, KokuUser
+from kokuqe.koku_models import KokuServiceAdmin, KokuCustomer, KokuUser
 
 @pytest.fixture
 def koku_config():
     return config.get_config().get('koku', {})
 
+@pytest.fixture
+def service_admin(koku_config):
+    return KokuServiceAdmin(username = koku_config.get('username'), password = koku_config.get('password'))
 
 @pytest.fixture
-def new_customer():
-    """Create a new Koku Kcustomer with random info"""
+def new_customer(service_admin):
+    """Create a new KokuCustomer with random info"""
     uniq_string = fauxfactory.gen_string('alphanumeric', 8)
     name='Customer {}'.format(uniq_string)
     owner={
@@ -20,17 +23,16 @@ def new_customer():
         'email': 'owner_{0}@{0}.com'.format(uniq_string),
         'password': 'redhat', }
 
-    #TODO: Implement lazy authentication of the client for new KokuObject() fixtures
-    return KokuCustomer(name=name, owner=owner)
+    return service_admin.create_customer(name=name, owner=owner)
 
 
 @pytest.fixture
-def new_user():
+def new_user(new_customer):
     """Create a new Koku user without authenticating to the server"""
     uniq_string = fauxfactory.gen_string('alphanumeric', 8)
+    new_customer.login()
 
-    #TODO: Implement lazy authentication of the client for new KokuObject() fixtures
-    return KokuUser(
+    return new_customer.create_user(
         username='user_{}'.format(uniq_string),
         email='user_{0}@{0}.com'.format(uniq_string),
         password='redhat')

--- a/kokuqe/tests/api/test_client.py
+++ b/kokuqe/tests/api/test_client.py
@@ -3,7 +3,7 @@ from kokuqe import api, config
 def test_api_client():
     koku_cfg = config.get_config().get('koku', {})
 
-    client = api.Client()
+    client = api.Client(username=koku_cfg.get('username'), password=koku_cfg.get('password'))
     assert client.token, 'No token provided after logging in'
 
     response = client.get_user()

--- a/kokuqe/tests/api/v1/test_customer.py
+++ b/kokuqe/tests/api/v1/test_customer.py
@@ -1,52 +1,59 @@
 import fauxfactory
 import pytest
 
-from kokuqe.koku_models import KokuCustomer, KokuUser
+from kokuqe import config
+from kokuqe.koku_models import KokuCustomer, KokuServiceAdmin, KokuUser
 
 
 class TestCustomerCrud(object):
     """Create a new customer, read the customer data from the server and delete the customer"""
 
     @pytest.fixture(scope='class')
-    def customer(self):
+    def service_admin(self):
+        koku_config = config.get_config().get('koku', {})
+
+        return KokuServiceAdmin(
+            username=koku_config.get('username'), password=koku_config.get('password'))
+
+    @pytest.fixture(scope='class')
+    def customer(self, service_admin):
         """Create a new Koku customer with random info"""
         uniq_string = fauxfactory.gen_string('alphanumeric', 8)
-        name='Customer {}'.format(uniq_string)
-        owner={
+        name = 'Customer {}'.format(uniq_string)
+        owner = {
             'username': 'owner_{}'.format(uniq_string),
             'email': 'owner_{0}@{0}.com'.format(uniq_string),
             'password': 'redhat', }
 
         #TODO: Implement lazy authentication of the client for new KokuObject()
-        return KokuCustomer(name=name, owner=owner)
-
+        return service_admin.create_customer(name=name, owner=owner)
 
     def test_customer_create(self, customer):
-        customer.create()
-
+        assert True
         assert customer.uuid, 'No customer uuid created for customer'
 
-    def test_customer_read(self, customer):
-        server_customer = customer.read().json()
+    def test_customer_read(self, service_admin, customer):
+        server_customer = service_admin.read_customer(customer.uuid)
 
-        assert server_customer['uuid'] == customer.uuid, 'Customer info cannot be read from the server'
+        assert server_customer.uuid == customer.uuid, (
+            'Customer info cannot be read from the server')
 
-        customer_list_response = customer.list().json()
-        assert customer_list_response['count'] > 0, 'No customers available on server'
+        customer_list = service_admin.list_customers()
+        assert len(customer_list) > 0, 'No customers available on server'
 
-        customer_uuid_list = [cust['uuid'] for cust in customer_list_response['results']]
-        assert customer.uuid in customer_uuid_list, 'Customer uuid is not listed in the Koku server list'
+        customer_uuid_list = [cust.uuid for cust in customer_list]
+        assert customer.uuid in customer_uuid_list, (
+            'Customer uuid is not listed in the Koku server list')
 
 
     @pytest.mark.skip(reason="Customer update not implemented")
     def test_customer_update(self, customer):
         assert 0
 
-    def test_customer_delete(self, customer):
-        customer.delete()
-        response = customer.list()
+    def test_customer_delete(self, service_admin, customer):
+        service_admin.delete_customer(customer.uuid)
+        customer_list = service_admin.list_customers()
 
-        response_results = response.json()['results']
-        for cust in response_results:
-            assert cust['uuid'] != customer.uuid, "Customer was not deleted from the koku server"
+        for cust in customer_list:
+            assert cust.uuid != customer.uuid, "Customer was not deleted from the koku server"
 

--- a/kokuqe/tests/api/v1/test_service_admin.py
+++ b/kokuqe/tests/api/v1/test_service_admin.py
@@ -1,0 +1,7 @@
+import fauxfactory
+import pytest
+
+from kokuqe.koku_models import KokuServiceAdmin, KokuCustomer, KokuUser
+
+def test_customer_list(koku_config, service_admin):
+    assert service_admin.get_current_user().json()['username'] == service_admin.username

--- a/kokuqe/tests/api/v1/test_user.py
+++ b/kokuqe/tests/api/v1/test_user.py
@@ -1,12 +1,20 @@
 import fauxfactory
 import pytest
 
-from kokuqe.koku_models import KokuCustomer, KokuUser
+from kokuqe import config
+from kokuqe.koku_models import KokuCustomer, KokuServiceAdmin, KokuUser
 
 
 class TestUserCrud(object):
     @pytest.fixture(scope='class')
-    def customer(self):
+    def service_admin(self):
+        koku_config = config.get_config().get('koku', {})
+
+        return KokuServiceAdmin(
+            username=koku_config.get('username'), password=koku_config.get('password'))
+
+    @pytest.fixture(scope='class')
+    def customer(self, service_admin):
         """Create a new Koku customer with random info"""
         uniq_string = fauxfactory.gen_string('alphanumeric', 8)
         name = 'Customer {}'.format(uniq_string)
@@ -15,53 +23,45 @@ class TestUserCrud(object):
             'email': 'owner_{0}@{0}.com'.format(uniq_string),
             'password': 'redhat', }
 
-        #TODO: Implement lazy authentication of the client for new KokuObject() fixtures
-        customer = KokuCustomer(name=name, owner=owner)
-        customer.create()
+        #TODO: Implement lazy authentication of the client for new KokuObject()
+        customer = service_admin.create_customer(name=name, owner=owner)
+        customer.login()
         assert customer.uuid, 'No customer uuid created for customer'
 
         yield customer
 
-        # Login as the admin user to delete the customer
-        customer.client.login()
-        customer.delete()
+        service_admin.delete_customer(customer.uuid)
 
     @pytest.fixture(scope='class')
-    def user(self):
+    def user(self, customer):
         """Create a new Koku user without authenticating to the server"""
         uniq_string = fauxfactory.gen_string('alphanumeric', 8)
 
         #TODO: Implement lazy authentication of the client for new KokuObject() fixtures
-        return KokuUser(
+        user = customer.create_user(
             username='user_{}'.format(uniq_string),
             email='user_{0}@{0}.com'.format(uniq_string),
             password='redhat')
 
+        return user
 
-    def test_user_create(self, customer, user):
+    def test_user_create(self, user):
         """Create a new user, read the user data from the server and delete the user"""
-        # Login as the newly created customer user
-        customer.client.login(
-            username=customer.owner['username'], password=customer.owner['password'])
-
-        # Use the token auth associated with the customer owner
-        user.client.token = customer.client.token
-
         # All requests will throw an exception if response is an error code
-        response = user.create()
         assert user.uuid, 'No uuid created for user'
 
+        assert  user.login(), "No token assigned to the user after login"
 
-    def test_user_read(self, user):
-        server_user = user.read().json()
+    def test_user_read(self, customer, user):
+        server_user = customer.read_user(user.uuid)
 
         # TODO: Overload equivalence for KokuObjects
-        assert server_user['uuid'] == user.uuid, 'User info cannot be read from the server'
+        assert server_user.uuid == user.uuid, 'User info cannot be read from the server'
 
-        user_list_response = user.list().json()
-        assert user_list_response['count'] > 0, 'No users available on server'
+        user_list = customer.list_users()
+        assert len(user_list) > 0, 'No users available on server'
 
-        user_uuid_list = [cust['uuid'] for cust in user_list_response['results']]
+        user_uuid_list = [cust.uuid for cust in user_list]
         assert user.uuid in user_uuid_list, 'user uuid is not listed in the Koku server list'
 
 
@@ -72,36 +72,33 @@ class TestUserCrud(object):
     def test_user_update_preference(self, user):
         name = 'editor'
         preference = {name: 'vim', }
-        #TODO: Refactor KokuObjects so that the client always matches the class context for auth
-        with user:
-            orig_user_pref = user.read_preference().json()['results']
 
-            pref_response = user.create_preference(name=name, preference=preference).json()
+        orig_user_pref = user.read_preference().json()['results']
 
-            assert pref_response['uuid'], 'New user preference was not assigned a uuid'
+        pref_response = user.create_preference(name=name, preference=preference).json()
+        assert pref_response['uuid'], 'New user preference was not assigned a uuid'
 
-            assert pref_response['user']['uuid'] == user.uuid, (
-                    'Preference user uuid does not match the current user uuid')
+        assert pref_response['user']['uuid'] == user.uuid, (
+                'Preference user uuid does not match the current user uuid')
 
-            #TODO: Is string data normalized when saved. Case Normalization, localization, ...
-            assert pref_response['name'] == name and pref_response['preference'] == preference, (
-                    'Created preference does not match the values supplied during creation')
+        #TODO: Is string data normalized when saved. Case Normalization, localization, ...
+        assert pref_response['name'] == name and pref_response['preference'] == preference, (
+                'Created preference does not match the values supplied during creation')
 
-            orig_pref_response = pref_response
-            pref_description = 'There is no other editor choice'
-            pref_response = user.update_preference(pref_response['uuid'], description=pref_description).json()
+        orig_pref_response = pref_response
+        pref_description = 'There is no other editor choice'
+        pref_response = user.update_preference(pref_response['uuid'], description=pref_description).json()
 
-            assert (
-                pref_response['description'] == pref_description and
-                pref_response['description'] != orig_pref_response['description'] and
-                pref_response['name'] == orig_pref_response['name'] and
-                pref_response['preference'] == orig_pref_response['preference']), (
-                    'Preference was not updated properly')
+        assert (
+            pref_response['description'] == pref_description and
+            pref_response['description'] != orig_pref_response['description'] and
+            pref_response['name'] == orig_pref_response['name'] and
+            pref_response['preference'] == orig_pref_response['preference']), (
+                'Preference was not updated properly')
 
     def test_user_delete(self, customer, user):
-        user.delete()
-        response = user.list()
+        customer.delete_user(user.uuid)
+        user_list = customer.list_users()
 
-        response_results = response.json()['results']
-        for server_user in response_results:
-            assert server_user['uuid'] != user.uuid, "User was not deleted from the koku server"
+        for server_user in user_list:
+            assert server_user.uuid != user.uuid, "User was not deleted from the koku server"


### PR DESCRIPTION
Refactoring the layout of everything in koku_models.*.  

This refactor *should* resolve issues with how we create objects by moving the entry point of creation/deletion to the user objects with permission to perform that action while leaving the logic for the CRUD action within target object.

- resolves https://github.com/project-koku/koku/issues/169
- resolves https://github.com/project-koku/hansei/issues/1
- resolves https://github.com/project-koku/hansei/issues/2
- resolves https://github.com/project-koku/hansei/issues/3
- resolves https://github.com/project-koku/hansei/issues/4