### PR TITLE
Fixture sessions_customer no only return customer listed in the yaml

### DIFF
--- a/hansei/koku_models.py
+++ b/hansei/koku_models.py
@@ -1,7 +1,8 @@
 # coding: utf-8
 """Models for use with the Koku API."""
 
-import decimal
+from decimal import Decimal
+
 from pprint import pformat
 from urllib.parse import urljoin
 
@@ -835,11 +836,11 @@ class KokuBaseReport(object):
         if not self.data:
             return None
 
-        total_item = decimal.Decimal(0.0)
+        total_item = Decimal(0.0)
         item_list = self.report_line_items(self.data)
         for item in item_list:
             total_item = total_item + (
-                decimal.Decimal(item['total']) if item['total'] else 0.0)
+                Decimal(item['total']) if item['total'] else Decimal(0))
 
         # Koku will return a null total if there are no line item charges in the list
         if len(item_list) == 0:

--- a/hansei/tests/api/v1/test_cost_report.py
+++ b/hansei/tests/api/v1/test_cost_report.py
@@ -54,7 +54,6 @@ def test_validate_totalcost(session_customers, report_filter, group_by):
         # Calculate sum of daily costs
         cost_sum = report.calculate_total()
 
-
         if cost_sum is None:
             assert len(report.report_line_items()) == 0, (
                 "Total cost is None but there are costs in the report")

--- a/hansei/tests/api/v1/test_instance_type_report.py
+++ b/hansei/tests/api/v1/test_instance_type_report.py
@@ -78,6 +78,6 @@ def test_validate_instance_uptime(session_customers, report_filter, group_by):
             assert len(report.report_line_items()) == 0, (
                 'VM uptime is None but the report shows instances')
         else:
-            assert report.total['count'] == vm_uptime, (
+            assert report.total['value'] == vm_uptime, (
                 'Report total is not equal to the sum of VM uptime from \
                 individual items')


### PR DESCRIPTION
Tests that used the session_customers fixtures were failing when customers not in the yaml were present on the server. Those non-yaml customers were failing during any test that required authentication.

Now session_customers only returns KokuCustomer objects for customers that exist in the yaml
